### PR TITLE
Make imagelib MirageOS-friendly

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,6 @@
 S .
 B _build
 
-PKG zlib
+PKG decompress
 
 FLG -w +A-4-18-41-42-44-48-58

--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,6 @@
+S .
+B _build
+
+PKG zlib
+
+FLG -w +A-4-18-41-42-44-48-58

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,11 +10,8 @@ all: imagelib.cma imagelib.cmxa META
 OCAMLF := $(shell which ocamlfind  2> /dev/null)
 OCAMLB := $(shell which ocamlbuild 2> /dev/null)
 
-# Try to find the camlzip library.
-CAMLZIP := $(shell ocamlfind query -format %p zip 2> /dev/null)
-ifeq ($(CAMLZIP),)
-	CAMLZIP := $(shell ocamlfind query -format %p camlzip 2> /dev/null)
-endif
+# Try to find the camldecompress library.
+CAMLDECOMPRESS := $(shell ocamlfind query -format %p decompress 2> /dev/null)
 
 # Try to find the bigarray library.
 BIGARRAY := $(shell ocamlfind query -format %p bigarray 2> /dev/null)
@@ -27,21 +24,22 @@ endif
 ifndef OCAMLF
 	$(error "The ocamlfind program is required...")
 endif
-ifeq ($(CAMLZIP),)
-	$(error "The zip / camlzip library is required...")
+ifeq ($(CAMLDECOMPRESS),)
+	$(error "The decompress library is required...")
 endif
 ifeq ($(BIGARRAY),)
 	$(error "The bigarray library is required...")
 endif
 
 _tags: depchecks GNUmakefile
-	@echo "true : package($(BIGARRAY)), package($(CAMLZIP))" > $@
+	@echo "true : package($(BIGARRAY)), package($(CAMLDECOMPRESS))" > $@
+	@echo "true : safe_string" >> $@
 
 META: depchecks
 	@echo "name=\"imagelib\"" > $@
 	@echo "version=\"0.1\"" >> $@
 	@echo "description=\"A library for reading / writing images\"" >> $@
-	@echo "requires=\"$(CAMLZIP),$(BIGARRAY)\"" >> $@
+	@echo "requires=\"$(CAMLDECOMPRESS),$(BIGARRAY)\"" >> $@
 	@echo "archive(byte)=\"imagelib.cma\"" >> $@
 	@echo "archive(native)=\"imagelib.cmxa\"" >> $@
 

--- a/image.ml
+++ b/image.ml
@@ -16,6 +16,9 @@
  *
  * Copyright (C) 2014 Rodolphe Lepigre.
  *)
+
+type chunk_reader = ImageUtil.chunk_reader
+
 module Pixmap =
   struct
     open Bigarray
@@ -57,8 +60,8 @@ type image =
 module type ReadImage =
   sig
     val extensions : string list
-    val size       : string -> int * int
-    val openfile   : string -> image
+    val size       : chunk_reader -> int * int
+    val parsefile   : chunk_reader -> (image, [> `Msg of string]) result
   end
 
 exception Corrupted_image of string
@@ -233,7 +236,7 @@ let write_greya i x y g a =
         Pixmap.set gg x y g;
         Pixmap.set aa x y a
       end
- 
+
 let write_grey i x y g =
   match i.pixels with
   | RGB(rr,gg,bb)

--- a/image.ml
+++ b/image.ml
@@ -61,7 +61,7 @@ module type ReadImage =
   sig
     val extensions : string list
     val size       : chunk_reader -> int * int
-    val parsefile   : chunk_reader -> (image, [> `Msg of string]) result
+    val parsefile  : chunk_reader -> (image, [> `Msg of string]) result
   end
 
 exception Corrupted_image of string

--- a/image.mli
+++ b/image.mli
@@ -63,9 +63,10 @@ exception Corrupted_image of string
 
 module type ReadImage =
   sig
+    open ImageUtil
     val extensions : string list
-    val size       : string -> int * int
-    val openfile   : string -> image
+    val size       : chunk_reader -> int * int
+    val parsefile  : chunk_reader -> (image, [> `Msg of string])  result
   end
 
 exception Not_yet_implemented of string

--- a/imageGIF.ml
+++ b/imageGIF.ml
@@ -35,7 +35,7 @@ module ReadGIF : ReadImage = struct
   let extensions = ["gif"]
 
   (* Read signature and header *)
-  let read_header ich =
+  let read_header (ich:ImageUtil.chunk_reader) =
     let magic = get_bytes ich 3 in
     if magic <> "GIF" then
       raise (Corrupted_image "GIF signature expected...");
@@ -44,9 +44,9 @@ module ReadGIF : ReadImage = struct
       raise (Corrupted_image "Version of GIF not supported...");
     let width  = get_bytes ich 2 in
     let height = get_bytes ich 2 in
-    let packed = input_byte ich in
-    let bgcol  = input_byte ich in
-    let pixar  = input_byte ich in
+    let packed = chunk_byte ich in
+    let bgcol  = chunk_byte ich in
+    let pixar  = chunk_byte ich in
     let w = ((int_of_char width.[1]) lsl 8) lor (int_of_char width.[0]) in
     let h = ((int_of_char height.[1]) lsl 8) lor (int_of_char height.[0]) in
     {
@@ -58,7 +58,7 @@ module ReadGIF : ReadImage = struct
       size_glob_col_tbl  = packed mod 8 ;
       bg_color_index     = bgcol ;
       pix_aspect_ratio   = pixar
-     }
+    }
 
   (* Read the size of a GIF image.
    * Arguments:
@@ -67,12 +67,11 @@ module ReadGIF : ReadImage = struct
    * Note: the image is not checked for inconsistency, only the signature and
    * header are checked.
    *)
-  let size fn =
-    let ich = open_in_bin fn in
+  let size ich =
     let hdr = read_header ich in
-    close_in ich;
+    ImageUtil.close_chunk_reader ich;
     hdr.image_size
 
-  let openfile fn =
+  let parsefile fn =
     raise (Not_yet_implemented "ImageGIF.openfile") (* TODO  *)
 end

--- a/imageJPG.ml
+++ b/imageJPG.ml
@@ -24,11 +24,11 @@ module ReadJPG : ReadImage = struct
   let extensions = ["jpg"; "jpeg"; "jpe"; "jif"; "jfif"; "jfi"]
 
   let read_marker ich =
-    let ff = input_byte ich in
+    let ff = chunk_byte ich in
     if ff <> 0xff then
       raise (Corrupted_image "Expected marker...");
     let rec read_first_not_ff ich =
-      let c = input_byte ich in
+      let c = chunk_byte ich in
       if c = 0xff then read_first_not_ff ich else c
     in
     let c = read_first_not_ff ich in
@@ -62,10 +62,9 @@ module ReadJPG : ReadImage = struct
    * Note: the image is not checked for inconsistency, only the signature and
    * header are checked.
    *)
-  let size fn =
-    let ich = open_in_bin fn in
+  let size ich =
     let headers = read_header_data ich in
-    close_in ich;
+    close_chunk_reader ich;
 
     let rec find_SOF ls =
       match ls with
@@ -83,6 +82,6 @@ module ReadJPG : ReadImage = struct
     let width = ((int_of_char sof.[3]) lsl 8) lor (int_of_char sof.[4]) in
     width, height
 
-  let openfile fn =
+  let parsefile fn =
     raise (Not_yet_implemented "ImageJPG.openfile") (* TODO  *)
 end

--- a/imageLib.ml
+++ b/imageLib.ml
@@ -47,41 +47,45 @@ let warning fn msg =
   Printf.eprintf "  PNG is the prefered format!\n%!"
 
 let size fn =
-  let ext = String.lowercase (get_extension' fn) in
+  let ext = String.lowercase_ascii (get_extension' fn) in
+  let ich = chunk_reader_of_path fn in
   if List.mem ext ReadPNG.extensions
-  then ReadPNG.size fn else
+  then ReadPNG.size ich else
   if List.mem ext ReadPPM.extensions
-  then ReadPPM.size fn else
+  then ReadPPM.size ich else
   if List.mem ext ReadXCF.extensions
-  then ReadXCF.size fn else
+  then ReadXCF.size ich else
   if List.mem ext ReadJPG.extensions
-  then ReadJPG.size fn else
+  then ReadJPG.size ich else
   if List.mem ext ReadGIF.extensions
-  then ReadGIF.size fn else
+  then ReadGIF.size ich else
   begin
     warning fn "No support for image size...";
     let fn' = temp_file "image" ".png" in
     convert fn fn';
-    let sz = ReadPNG.size fn' in
+    let ich' = chunk_reader_of_path fn' in
+    let sz = ReadPNG.size ich' in
     rm fn'; sz
   end
 
-let openfile fn =
-  let ext = String.lowercase (get_extension' fn) in
+let openfile fn : (image, 'a) result =
+  let ext = String.lowercase_ascii (get_extension' fn) in
+  let ich = chunk_reader_of_path fn in
   if List.mem ext ReadPNG.extensions
-  then ReadPNG.openfile fn else
+  then ReadPNG.parsefile ich else
   if List.mem ext ReadPPM.extensions
-  then ReadPPM.openfile fn else
+  then ReadPPM.parsefile ich else
   begin
     warning fn "Cannot read this image format...";
     let fn' = temp_file "image" ".png" in
     convert fn fn';
-    let img = ReadPNG.openfile fn' in
+    let ich' = chunk_reader_of_path fn' in
+    let img = ReadPNG.parsefile ich' in
     rm fn'; img
   end
 
 let writefile fn i =
-  let ext = String.lowercase (get_extension' fn) in
+  let ext = String.lowercase_ascii (get_extension' fn) in
   if List.mem ext ReadPNG.extensions
   then write_png fn i else
   if List.mem ext ReadPPM.extensions

--- a/imageLib.mli
+++ b/imageLib.mli
@@ -26,7 +26,7 @@ val size : string -> int * int
 (* [openfile fn] reads the image in the file [fn]. This function guesses the
    image format using the extension, and raises [Corrupted_image msg] in
    case of problem. *)
-val openfile : string -> Image.image
+val openfile : string -> (Image.image, [`Msg of string]) result
 
 (* [writefile fn img] writes the image [img] to the file [fn]. This function
    guesses the desired format using the extension. *)

--- a/imageLib.mli
+++ b/imageLib.mli
@@ -26,7 +26,7 @@ val size : string -> int * int
 (* [openfile fn] reads the image in the file [fn]. This function guesses the
    image format using the extension, and raises [Corrupted_image msg] in
    case of problem. *)
-val openfile : string -> (Image.image, [`Msg of string]) result
+val openfile : string -> Image.image
 
 (* [writefile fn img] writes the image [img] to the file [fn]. This function
    guesses the desired format using the extension. *)

--- a/imagePNG.ml
+++ b/imagePNG.ml
@@ -42,60 +42,77 @@ type pixel =
   { r : int ; g : int ; b : int }
 
 (****************************************************************************
- * Zlib compression functions relying on ocaml-zip                          *
+ * Zlib compression functions relying on decompress
+
  ****************************************************************************)
 module PNG_Zlib = struct
   exception PNG_Zlib_error of string
- 
-  let uncompress_string inputstr =
-    let len = String.length inputstr in
+
+  open Decompress
+
+  let uncompress_string (input_ro:string) : string =
+    let inputstr = Bytes.of_string input_ro in
+    let len = Bytes.length inputstr in
     let inputpos = ref 0 in
-    let output = ref [] in
-  
-    let refill strbuf =
-      let buflen = String.length strbuf in
+    let input_temp, output_temp = Bytes.(create 0xFFFF, create 0xFFFF) in
+    let final_output = Buffer.create (len / 3) in (* approx avg rate *)
+
+    let refill (strbuf:Bytes.t) : int =
       let remaining = len - !inputpos in
-      let tocopy = min remaining buflen in
-      String.blit inputstr !inputpos strbuf 0 tocopy;
+      let tocopy = min 0xFFFF remaining in
+      Bytes.blit inputstr !inputpos strbuf 0 tocopy;
       inputpos := !inputpos + tocopy;
       tocopy
     in
-  
+
     let flush strbuf len =
-      let str = String.sub strbuf 0 len in
-      output := str :: !output;
+      Buffer.add_subbytes final_output strbuf 0 len ;
+      0xFFFF
     in
-  
-    (try Zlib.uncompress refill flush with Zlib.Error(msg,_) ->
-      let msg = Printf.sprintf "Zlib.uncompress failed (%s) ..." msg in
-      raise (PNG_Zlib_error msg));
-  
-    String.concat "" (List.rev !output)
-  
-  let compress_string inputstr =
+
+    let window = Window.create ~proof:B.proof_bytes in
+
+    begin match
+        Inflate.bytes input_temp output_temp
+          refill flush Inflate.(default window) with
+    | Error _ ->
+      let msg = Printf.sprintf "Decompress.Inflate.bytes failed ..." in
+      raise (PNG_Zlib_error msg);
+    | Ok _ -> Buffer.contents final_output
+    end
+
+  let compress_string (inputstr:string) : string =
     let len = String.length inputstr in
     let inputpos = ref 0 in
-    let output = ref [] in
-  
-    let refill strbuf =
-      let buflen = String.length strbuf in
+    let input_temp, output_temp = Bytes.(create 0xFFFF , create 0xFFFF) in
+    let final_output = Buffer.create (len * 3) in (* approx avg rate *)
+
+    let refill strbuf _max : int =
+      let max = match _max with None -> 0xFFFF | Some m -> m in
       let remaining = len - !inputpos in
-      let tocopy = min remaining buflen in
-      String.blit inputstr !inputpos strbuf 0 tocopy;
+      let tocopy = min max remaining in
+      Bytes.blit_string inputstr !inputpos strbuf 0 tocopy;
       inputpos := !inputpos + tocopy;
       tocopy
     in
-  
-    let flush strbuf len =
-      let str = String.sub strbuf 0 len in
-      output := str :: !output;
+
+    let flush strbuf f_len =
+      Buffer.add_subbytes final_output strbuf 0 f_len ; 0xFFFF
     in
-  
-    (try Zlib.compress refill flush with Zlib.Error(msg,_) ->
-      let msg = Printf.sprintf "Zlib.compress failed (%s) ..." msg in
-      raise (PNG_Zlib_error msg));
-  
-    String.concat "" (List.rev !output)
+
+    (* Computations<->size trade-off (see Decompress.Deflate.default): *)
+    let compression_level = 4 in
+
+    let window = Deflate.default ~proof:B.proof_bytes compression_level in
+
+    begin match Deflate.bytes input_temp output_temp
+                  refill flush window with
+    | Error _ ->
+      let msg = Printf.sprintf "Decompress.Deflate.bytes failed ..." in
+      raise (PNG_Zlib_error msg)
+    | Ok _ -> Buffer.contents final_output
+    end
+
 end
 
 open PNG_Zlib
@@ -243,7 +260,7 @@ module ReadPNG : ReadImage = struct
    *   - prev_scanline : previous scanline with filter removed.
    * Returns the unfiltered scanline.
    *)
-  let unfilter ftype bpp scanline prev_scanline =
+  let unfilter ftype bpp scanline prev_scanline : string =
     let paeth_predictor a b c =
       let p = a + b - c in
       let pa = abs (p - a) in
@@ -253,15 +270,15 @@ module ReadPNG : ReadImage = struct
       then a
       else (if pb <= pc then b else c)
     in
-  
+
     let slen = String.length scanline in
-    let unfiltered = String.create slen in
-  
+    let unfiltered = Bytes.create slen in
+
     for x = 0 to slen - 1 do
       let filtx = int_of_char scanline.[x] in
       let recona =
         let j = x - bpp in
-        if j < 0 then 0 else int_of_char unfiltered.[j]
+        if j < 0 then 0 else int_of_char (Bytes.get unfiltered j)
       in
       let reconb =
         match prev_scanline with
@@ -285,10 +302,10 @@ module ReadPNG : ReadImage = struct
          | _ -> let msg = Printf.sprintf "Unknown filter type (%i)..." ftype in
                 raise (Corrupted_image msg)
       in
-      String.set unfiltered x (char_of_int recon)
+      Bytes.set unfiltered x (char_of_int recon)
     done;
-    unfiltered
-  
+    Bytes.to_string unfiltered
+
   (*
    * Pass extraction function.
    * Arguments :
@@ -308,7 +325,7 @@ module ReadPNG : ReadImage = struct
     let rowsize_bit = w * pl_bit in
     let rowsize = rowsize_bit / 8 + if rowsize_bit mod 8 <> 0 then 1 else 0 in
     let zchar = char_of_int 0 in
-    let output = Array.init h (fun _ -> String.make rowsize zchar) in
+    let output = Array.init h (fun _ -> Bytes.make rowsize zchar) in
   
     let input_byte = ref 0 in
     let input_bit = ref 0 in
@@ -360,7 +377,7 @@ module ReadPNG : ReadImage = struct
         String.make 1 (char_of_int pix)
       end
     in
-  
+
     let flush_end_of_byte () =
       if !input_bit <> 0
       then begin
@@ -368,8 +385,8 @@ module ReadPNG : ReadImage = struct
         incr input_byte
       end
     in
-  
-    (* Writes the pixel pix at pixel position pos in the string str. *)
+
+    (* Writes the pixel pix at pixel position pos in the `bytes` str. *)
     let output_pixel pix pos str =
       if pl_bit mod 8 = 0
       then begin
@@ -381,7 +398,7 @@ module ReadPNG : ReadImage = struct
         let bitpos = pos * pl_bit in
         let byte = bitpos / 8 in
         let bit = bitpos mod 8 in
-        let content = int_of_char str.[byte] in
+        let content = int_of_char @@ Bytes.get str byte in
         let mask = lnot (((ones pl_bit) lsl (8 - pl_bit)) lsr bit) in
         let newcontent = (content land mask) lor (pixv lsr bit) in
         str.[byte] <- char_of_int newcontent;
@@ -397,8 +414,8 @@ module ReadPNG : ReadImage = struct
         (* DEBUG FIXME *)
       end
     in
-  
-    let sl = String.make (w * 8) zchar in (* ugly... (2bytes x 4 component) *)
+
+    let sl = Bytes.make (w * 8) zchar in (* ugly... (2bytes x 4 component) *)
     let slpos = ref 0 in
   
     for pass = 0 to 6 do
@@ -437,21 +454,21 @@ module ReadPNG : ReadImage = struct
           if bitlen mod 8 <> 0 then begin
             let nbbits = bitlen mod 8 in
             let mask = ones nbbits lsl (8 - nbbits) in
-            let last = int_of_char sl.[sllen - 1] in
+            let last = int_of_char @@ Bytes.get sl (sllen - 1) in
             sl.[sllen - 1] <- char_of_int (last land mask)
           end;
-          let sl = String.sub sl 0 sllen in
+          let sl = Bytes.sub sl 0 sllen in
           let bpp = max (pl_bit / 8) 1 in
-          let slunfilt = unfilter !ft bpp sl !prevsl in
+          let slunfilt = unfilter !ft bpp (Bytes.to_string sl) !prevsl in
           prevsl := Some slunfilt;
-  
+
           col := starting_col.(pass);
           slpos := 0;
           while !col < w do
             let pix = read_pix slunfilt !slpos in
             incr slpos;
             output_pixel pix !col output.(!row);
-  
+
             col := !col + col_increment.(pass)
           done;
         end;
@@ -470,10 +487,10 @@ module ReadPNG : ReadImage = struct
 
   let parsefile ich =
     read_signature ich;
-  
+
     let curr_chunck = ref (read_chunck ich) in
     let read_chuncks = ref [] in
-  
+
     let only_once ctype =
       if List.mem ctype !read_chuncks
       then begin
@@ -647,7 +664,7 @@ module ReadPNG : ReadImage = struct
                end
            (* IEND cannot occur (end condition of the loop) *)
            (* | "IEND" -> *)
-  
+
            (* Ancillary chunks *)
            | "cHRM" ->
                only_once curr_ctype;
@@ -785,12 +802,13 @@ module ReadPNG : ReadImage = struct
         (close_chunk_reader ich;
          raise (Corrupted_image "End of file reached before chunck end..."))
     end;
-  
+
     (* Check for trailing bytes... *)
     if (try let _ = chunk_byte ich in true with End_of_file -> false)
     then raise (Corrupted_image "Data after the IEND chunck...");
+
     close_chunk_reader ich;
-  
+
     let uncomp_idat = uncompress_string !raw_idat in
   
     let w, h = !ihdr.image_size in
@@ -827,7 +845,7 @@ module ReadPNG : ReadImage = struct
              (ft, sl)
            )
          in
-       
+
          (* Removing the filter on the scanlines *)
          let prev_scanline = ref None in
          Array.mapi
@@ -838,13 +856,13 @@ module ReadPNG : ReadImage = struct
        | 1 ->
          if !debug then Printf.fprintf stderr "Interlace method 1.\n%!";
          let pixlen_bit = nb_comp * bd in
-         extract_pass uncomp_idat pixlen_bit w h
+         extract_pass uncomp_idat pixlen_bit w h |> Array.map (Bytes.to_string)
        | _ -> assert false
     in
-  
+
     (* Conversion of the array of string into an array of array of int *)
     let unfiltered_int = Array.init h (fun y -> Array.make (w * nb_comp) 0) in
-  
+
     for y = 0 to h - 1 do
       for x = 0 to (w * nb_comp) - 1 do
         match bd with
@@ -904,7 +922,7 @@ module ReadPNG : ReadImage = struct
            let index = (* FIXME *)
              if index >= Array.length !palette
              then (Printf.fprintf stderr "Palette index too big...\n%!"; 0)
-             else index 
+             else index
            in
            let p = !palette.(index) in
            write_rgb image x y p.r p.g p.b
@@ -916,7 +934,7 @@ module ReadPNG : ReadImage = struct
        let image = create_grey ~alpha:true ~max_val:(ones bd) w h in
        for y = 0 to h - 1 do
          for x = 0 to w - 1 do
-           write_greya image x y 
+           write_greya image x y
              unfiltered_int.(y).(2 * x)
              unfiltered_int.(y).(2 * x + 1);
          done
@@ -947,7 +965,7 @@ let write_signature och =
 
 let write_chunk och chunck =
   let len = String.length chunck.chunck_data in
-  output_string och (int_to_str4 len);
+  output_string och (int_to_str4 len |> Bytes.to_string);
   output_string och chunck.chunck_type;
   output_string och chunck.chunck_data;
   let type_and_data = String.concat ""
@@ -963,15 +981,15 @@ let write_chunk och chunck =
   output_char och (char_of_int crc0)
 
 let ihdr_to_string ihdr =
-  let s = String.create 13 in
-  String.blit (int_to_str4 (fst ihdr.image_size)) 0 s 0 4;
-  String.blit (int_to_str4 (snd ihdr.image_size)) 0 s 4 4;
+  let s = Bytes.create 13 in
+  Bytes.blit (int_to_str4 (fst ihdr.image_size)) 0 s 0 4;
+  Bytes.blit (int_to_str4 (snd ihdr.image_size)) 0 s 4 4;
   s.[8] <- char_of_int ihdr.bit_depth;
   s.[9] <- char_of_int ihdr.colour_type;
   s.[10] <- char_of_int ihdr.compression_method;
   s.[11] <- char_of_int ihdr.filter_method;
   s.[12] <- char_of_int ihdr.interlace_method;
-  s
+  Bytes.to_string s
 
 let write_png fn img =
   let och = open_out_bin fn in

--- a/imageUtil.ml
+++ b/imageUtil.ml
@@ -16,6 +16,11 @@
  *
  * Copyright (C) 2014 Rodolphe Lepigre.
  *)
+
+type chunk_reader_error = [`End_of_file]
+type chunk_reader = ([`Bytes of int | `Close]) ->
+                    (string, chunk_reader_error) result
+
 open Pervasives
 
 (** [chop_extension' fname] is the same as [Filename.chop_extension fname] but
@@ -155,9 +160,31 @@ let show_string_hex s =
  *   - n : number of bytes to fecth
  * Returns a string of length n.
  *)
-let get_bytes ich n =
-  let str = String.create n in
-  really_input ich str 0 n; str
+let get_bytes (reader:chunk_reader) num_bytes =
+  reader (`Bytes num_bytes)
+  |> function | Ok x -> x
+       | _ -> failwith "Failed to read expected number of bytes from stream"
+
+let chunk_char (reader:chunk_reader) = String.get (get_bytes reader 1) 0
+let chunk_byte (reader:chunk_reader) = chunk_char reader |> Char.code
+
+let chunk_reader_of_in_channel ich : chunk_reader =
+  function
+  | `Bytes num_bytes ->
+    begin try Ok (really_input_string ich num_bytes)
+    with End_of_file -> Error `End_of_file end
+  | `Close -> close_in ich; Ok ""
+
+let chunk_reader_of_path fn = chunk_reader_of_in_channel (open_in_bin fn)
+let close_chunk_reader (reader:chunk_reader) = ignore (reader `Close)
+let chunk_line (reader:chunk_reader) =
+  let rec loop acc =
+    match chunk_char reader with
+    | '\n' ->
+      let a = Array.of_list acc in
+      Bytes.init (Array.length a) (fun i -> a.(i)) |> Bytes.to_string
+    | c  -> loop (c::acc)
+  in loop []
 
 let print_byte v =
   for i = 7 downto 0 do

--- a/imageXCF.ml
+++ b/imageXCF.ml
@@ -64,12 +64,11 @@ module ReadXCF : ReadImage = struct
    * Note: the image is not checked for inconsistency, only the signature and
    * header are checked.
    *)
-  let size fn =
-    let ich = open_in_bin fn in
+  let size ich =
     let hdr = read_header ich in
-    close_in ich;
+    close_chunk_reader ich;
     hdr.image_size
 
-  let openfile fn =
+  let parsefile fn =
     raise (Not_yet_implemented "ImageXCF.openfile") (* TODO  *)
 end


### PR DESCRIPTION
Hello!

I really wanted PNG rendering in MirageOS; I got that working with this patch (so now I have a portable "gallery viewer" that works on Linux and Xen/Qubes - very happy!).

It's a bit invasive, sorry about that. If there are things you'd like to change, I'd be happy to do that. :-)

I only tested PNG parsing, so there may be subtle bugs introduced. I hope not, but now you are warned.

This patch:
- switches the compression library from `camlzip` to the pure `decompress` (addressing #1 )
- changes the name `openfile` to `parsefile` (hope that is OK)
- replaces `String.lowercase` with `String.lowercase_ascii` (to get rid of deprecation warnings)
- adds `safe_string` (which will be default in future OCaml releases, hopefully soon), enforcing the distinction between immutable strings (`string`) and mutable strings (`Bytes.t`)
- changes the chunk reading functions from the Unix/Windows-only `in_channel` functions to use a pluggable method, defined at the top of `ImageUtil.ml`
  - implements `ImageUtil.chunk_reader_of_in_channel` and `chunk_reader_of_path` for backwards compatibility, so `ImageLib.openfile` still works.
- in `imagePNG.ml`, which was the file I mainly worked on, it also
  - switches `Scanf.fscanf`, which is deprecated since 4.03.0 due to bugs, to `Scanf.bscanf` (`fscanf` also doesn't work on MirageOS)

ping @rlepigre @dinosaure
