### PR TITLE
Update the README to s/camlzip/decompress/, bump release version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,16 @@
-The imagelib library implements image formats such as PNG or PPM
+The imagelib library implements image formats such as PNG and PPM
 
-The imagelib library implements image formats such as PNG or PPM  in
-OCaml, relying on only one external dependency: camlzip. However, we
-plan to reimplement zlib in OCaml at some point.
+The imagelib library implements image formats such as PNG and PPM  in
+OCaml, relying on only one external dependency: 'decompress'.
 
 Supported image formats:
- - PNG (full implementation of RCF 2083),
+ - PNG (full implementation of RFC 2083),
  - PPM, PGM, PBM, ... (fully supported),
  - JPG (only image size natively, conversion to PNG otherwise),
  - GIF (only image size natively, conversion to PNG otherwise),
  - XCF (only image size natively, conversion to PNG otherwise),
- - Other formats rely on convert (imagemagick).
+ - Other formats rely on 'convert' (imagemagick).
 
-As imagelib only requires camlzip, it is suitable for compilation to
+As imagelib only requires 'decompress', it is suitable for compilation to
 javascript using js_of_ocaml (only for operations not requireing the
 convert binary).

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@ OCAMLBUILD := ocamlbuild
 FLAGS := -cflags -w,-3 -use-ocamlfind
 IMPLFILES := $(wildcard *.ml)
 INTFFILES := $(wildcard *.mli)
-VERSION := 20170118
+VERSION := 20171028
 
 all: imagelib.cma imagelib.cmxa META
 

--- a/README
+++ b/README
@@ -1,26 +1,25 @@
 ### Description ###
 
-The imagelib library implements image formats such as PNG or PPM  in
-OCaml, relying on only one external dependency: camlzip. However, we
-plan to reimplement zlib in OCaml at some point.
+The imagelib library implements image formats such as PNG and PPM  in
+OCaml, relying on only one external dependency: `decompress`.
 
 Supported image formats:
- - PNG (full implementation of RCF 2083),
+ - PNG (full implementation of RFC 2083),
  - PPM, PGM, PBM, ... (fully supported),
  - JPG (only image size natively, conversion to PNG otherwise),
  - GIF (only image size natively, conversion to PNG otherwise),
  - XCF (only image size natively, conversion to PNG otherwise),
  - Other formats rely on convert (imagemagick).
 
-As imagelib only requires camlzip, it is suitable for compilation to
-javascript using js_of_ocaml (only for operations not requireing the
+As imagelib only requires `decompress`, it is suitable for compilation to
+javascript using js_of_ocaml (only for operations not requiring the
 convert binary).
 
 ### Dependencies ###
 
 List of dependencies:
  - OCaml
- - Camlzip
+ - decompress
  - Findlib (build)
  - OCamlbuild (build)
  - GNU Make (build)


### PR DESCRIPTION
Missed these in the previous PR ( https://github.com/rlepigre/ocaml-imagelib/pull/3 ).

Do you think we can cut a new opam release with this?