### PR TITLE
compile with -bin_annot to support merlin (fixes #7)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,6 +34,7 @@ endif
 _tags: depchecks GNUmakefile
 	@echo "true : package($(BIGARRAY)), package($(CAMLDECOMPRESS))" > $@
 	@echo "true : safe_string" >> $@
+	@echo "true : bin_annot" >> $@
 
 META: depchecks
 	@echo "name=\"imagelib\"" > $@


### PR DESCRIPTION
This addresses one of the concerns raised in https://github.com/rlepigre/ocaml-imagelib/issues/7