### PR TITLE
Mirage compatibility by splitting off Unix-dependent functionality

### DIFF
--- a/imagelib-unix.opam
+++ b/imagelib-unix.opam
@@ -1,0 +1,39 @@
+synopsis: "The imagelib library implements image formats such as PNG and PPM"
+description:
+"""
+The imagelib library implements image formats such as PNG and PPM
+
+The imagelib library implements image formats such as PNG and PPM in
+OCaml, relying on only one external dependency: 'decompress'.
+
+Supported image formats:
+ - PNG (full implementation of RFC 2083),
+ - PPM, PGM, PBM, ... (fully supported),
+ - JPG (only image size natively, conversion to PNG otherwise),
+ - GIF (only image size natively, conversion to PNG otherwise),
+ - XCF (only image size natively, conversion to PNG otherwise),
+ - Other formats rely on 'convert' (imagemagick).
+
+As imagelib only requires 'decompress', it can be used together with
+js_of_ocaml to compile projects to Javascript. Note that some of the
+features of imagelib require the convert binary  (and thus cannot be
+used from Javascript).
+"""
+opam-version: "2.0"
+maintainer: "rodolphe.lepigre@inria.fr"
+bug-reports: "https://github.com/rlepigre/imagelib/issues"
+homepage: "https://github.com/rlepigre/imagelib"
+dev-repo: "git+https://github.com/rlepigre/imagelib.git"
+authors: [
+  "Rodolphe Lepigre <rodolphe.lepigre@inria.fr>"
+]
+license: "GPLv3"
+doc: "https://github.com/rlepigre/imagelib"
+
+depends: [
+  "ocaml"        {         >= "4.03.0" }
+  "dune"         { build & >= "1.3.0"  }
+  "imagelib"
+]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]

--- a/imagelib-unix.opam
+++ b/imagelib-unix.opam
@@ -1,23 +1,18 @@
-synopsis: "The imagelib library implements image formats such as PNG and PPM"
+synopsis: "Utility library for 'imagelib' with Unix-dependent functionality"
 description:
 """
-The imagelib library implements image formats such as PNG and PPM
+This package implements Unix-dependent functionality for the 'imagelib' library.
 
-The imagelib library implements image formats such as PNG and PPM in
-OCaml, relying on only one external dependency: 'decompress'.
+This includes operations like interacting with the filesystem
+(reading or writing to files).
 
-Supported image formats:
- - PNG (full implementation of RFC 2083),
- - PPM, PGM, PBM, ... (fully supported),
- - JPG (only image size natively, conversion to PNG otherwise),
- - GIF (only image size natively, conversion to PNG otherwise),
- - XCF (only image size natively, conversion to PNG otherwise),
- - Other formats rely on 'convert' (imagemagick).
-
-As imagelib only requires 'decompress', it can be used together with
-js_of_ocaml to compile projects to Javascript. Note that some of the
-features of imagelib require the convert binary  (and thus cannot be
-used from Javascript).
+Another feature is supported for unimplemented image formats through an
+intermediate step of converting the image to PNG format
+using the 'convert' command from the 'imagemagick' operating system package,
+if installed. While ImageMagick is required for this feature, is is not a hard
+dependency of this OPAM package since that would prevent people who can't
+install imagemagick from using 'imagelib-unix' to read or write the implemented
+file formats.
 """
 opam-version: "2.0"
 maintainer: "rodolphe.lepigre@inria.fr"

--- a/imagelib.opam
+++ b/imagelib.opam
@@ -1,23 +1,24 @@
-synopsis: "The imagelib library implements image formats such as PNG and PPM"
+synopsis: "Library implementing parsing of image formats such as PNG, BMP, PPM"
 description:
 """
-The imagelib library implements image formats such as PNG and PPM
-
-The imagelib library implements image formats such as PNG and PPM in
+The imagelib library implements image formats such as PNG, BMP, and PPM in
 OCaml, relying on only one external dependency: 'decompress'.
+
+Unix-dependent functionality such as reading or writing to files in the
+filesystem are packaged separately in the 'imagelib-unix' OPAM package.
 
 Supported image formats:
  - PNG (full implementation of RFC 2083),
  - PPM, PGM, PBM, ... (fully supported),
+ - BMP (read-only)
  - JPG (only image size natively, conversion to PNG otherwise),
  - GIF (only image size natively, conversion to PNG otherwise),
  - XCF (only image size natively, conversion to PNG otherwise),
- - Other formats rely on 'convert' (imagemagick).
+ - Utility functions for handling unimplemented formats are available in
+   the 'imagelib-unix' OPAM package. See that package description for more info.
 
 As imagelib only requires 'decompress', it can be used together with
-js_of_ocaml to compile projects to Javascript. Note that some of the
-features of imagelib require the convert binary  (and thus cannot be
-used from Javascript).
+js_of_ocaml to compile projects to Javascript, or from MirageOS unikernels.
 """
 opam-version: "2.0"
 maintainer: "rodolphe.lepigre@inria.fr"
@@ -37,3 +38,10 @@ depends: [
 ]
 
 build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
+
+messages: [
+  "We recently changed the API and split off the Unix-dependent parts"
+  "to a separate opam library, 'imagelib-unix'. If you are missing something,"
+  " please try installing imagelib-unix and see if "
+  "ImageLib_unix or ImageUtil_unix expose the required functionality."
+]

--- a/src/dune
+++ b/src/dune
@@ -3,5 +3,6 @@
  (public_name imagelib)
  (synopsis "Image library")
  (modules :standard)
+ (flags (:standard -safe-string))
  (wrapped false)
  (libraries bigarray decompress))

--- a/src/dune
+++ b/src/dune
@@ -5,4 +5,4 @@
  (modules :standard)
  (flags (:standard -safe-string))
  (wrapped false)
- (libraries bigarray decompress))
+ (libraries bigarray checkseum.ocaml decompress))

--- a/src/imageChannels.ml
+++ b/src/imageChannels.ml
@@ -4,8 +4,18 @@ module type OUT_CHANNEL = sig
     val output_char : out_channel -> char -> unit
 end
 
-module Buffer_channel = struct
+module Buffer_channel
+  : OUT_CHANNEL with type out_channel = Buffer.t
+= struct
     type out_channel = Buffer.t
     let output_string = Buffer.add_string
     let output_char = Buffer.add_char
   end
+
+module Chunk_channel
+  : OUT_CHANNEL with type out_channel = ImageUtil.chunk_writer
+= struct
+  type out_channel = ImageUtil.chunk_writer
+  let output_string = ImageUtil.chunk_write
+  let output_char = ImageUtil.chunk_write_char
+end

--- a/src/imageLib.ml
+++ b/src/imageLib.ml
@@ -18,7 +18,6 @@
  *)
 
 open Image
-(*open ImageUtil*)
 
 open ImagePNG
 open ImagePPM

--- a/src/imageLib.mli
+++ b/src/imageLib.mli
@@ -17,6 +17,7 @@
  * Copyright (C) 2014 Rodolphe Lepigre.
  *)
 open Image
+open ImageUtil
 
 (* [size fn] returns a couple [(w,h)] corresponding to the size of the image
    contained in the file [fn]. The exception [{!Corrupted_image} msg] is raised
@@ -24,7 +25,7 @@ open Image
    NB: This will try to run the command "convert" from imagemagick
    to convert to PNG if the file extension is unknown.
 *)
-val size : string -> int * int
+val size : extension:string -> ImageUtil.chunk_reader -> int * int
 
 (* [openfile fn] reads the image in the file [fn]. This function guesses the
    image format using the extension, and raises [{!Corrupted_image} msg] in
@@ -32,17 +33,11 @@ val size : string -> int * int
    NB: If the file extension is unknown, this will launch "convert" from
    imagemagick and attempt to convert to PNG before opening.
 *)
-val openfile : string -> Image.image
+val openfile : extension:string -> ImageUtil.chunk_reader -> Image.image
 
-(* [writefile fn img] writes the image [img] to the file [fn]. This function
-   guesses the desired format using the extension.
-   Raises {!Corrupted_image} if it encounters a problem.
-   If the file extension is unknown to imagelib, this will first write out a PNG
-   and then convert that to the desired format using the "convert"
-   command from imagemagick.
-*)
-val writefile : string -> Image.image -> unit
 
+val writefile : extension:string ->
+  ImageUtil.chunk_writer -> Image.image -> unit
 
 module PPM :
   sig
@@ -50,14 +45,14 @@ module PPM :
 
     type ppm_mode = Binary | ASCII
 
-    val write_ppm : string -> image -> ppm_mode -> unit
+    val write_ppm : chunk_writer -> image -> ppm_mode -> unit
   end
 
 module PNG :
   sig
     module ReadPNG : ReadImage
 
-    val write_png : string -> image -> unit
+    val write_png : chunk_writer -> image -> unit
 
     val bytes_of_png : image -> Bytes.t
   end

--- a/unix/dune
+++ b/unix/dune
@@ -1,0 +1,8 @@
+(library
+ (name imagelib_unix)
+ (public_name imagelib-unix)
+ (synopsis "Image library with unix bindings")
+ (modules :standard)
+ (flags (:standard -safe-string))
+ (wrapped false)
+ (libraries imagelib))

--- a/unix/imageLib_unix.ml
+++ b/unix/imageLib_unix.ml
@@ -1,0 +1,70 @@
+open Image
+open ImageUtil_unix
+
+module PNG = struct
+  include ImagePNG
+  module PngUnixWrite = PngWriter(Unix_channel)
+end
+module PPM = ImagePPM
+module XCF = ImageXCF
+module JPG = ImageJPG
+module GIF = ImageGIF
+
+let warning fn msg =
+  Printf.eprintf "[WARNING imagelib] file %s\n" fn;
+  Printf.eprintf "  %s\n" msg;
+  Printf.eprintf "  PNG is the prefered format!\n%!"
+
+let convert fn fn' =
+  let ret =
+    Unix.create_process "convert" [| "convert"; fn ; fn' |]
+      (* "--" ; see:
+       https://github.com/rlepigre/ocaml-imagelib/pull/15#discussion_r198867027
+      *)
+      Unix.stdin Unix.stdout Unix.stderr in
+  if ret <> 0 then
+    raise (Failure (Printf.sprintf "convert fn:%S fn':%S failed" fn fn'))
+
+let rm fn =
+  Sys.remove fn
+
+let size fn =
+  let extension = (get_extension' fn) in
+  let ich = chunk_reader_of_path fn in
+  try ImageLib.size ~extension ich with
+  | Image.Not_yet_implemented _ ->
+    begin
+      warning fn "No support for image size...";
+      let fn' = Filename.temp_file "image" ".png" in
+      convert fn fn';
+      let ich' = ImageUtil_unix.chunk_reader_of_path fn' in
+      let sz = ImagePNG.ReadPNG.size ich' in
+      rm fn'; sz
+    end
+
+let openfile fn : image =
+  let extension = (get_extension' fn) in
+  let ich = chunk_reader_of_path fn in
+  try ImageLib.openfile ~extension ich with
+  | Image.Not_yet_implemented _ ->
+    begin
+      warning fn "Cannot read this image format...";
+      let fn' = Filename.temp_file "image" ".png" in
+      convert fn fn';
+      let ich' = ImageUtil_unix.chunk_reader_of_path fn' in
+      let img = ImagePNG.ReadPNG.parsefile ich' in
+      rm fn'; img
+    end
+
+let writefile fn i =
+  let extension = get_extension' fn in
+  let och = ImageUtil_unix.chunk_writer_of_path fn in
+  try ImageLib.writefile ~extension och i with
+  | Not_yet_implemented _ ->
+    begin
+      warning fn "Cannot write to this image format...";
+      let fn' = Filename.temp_file "image" ".png" in
+      ImagePNG.write_png och i;
+      convert fn' fn;
+      rm fn'
+    end

--- a/unix/imageLib_unix.mli
+++ b/unix/imageLib_unix.mli
@@ -1,0 +1,12 @@
+(* [writefile fn img] writes the image [img] to the file [fn]. This function
+   guesses the desired format using the extension.
+   Raises {!Corrupted_image} if it encounters a problem.
+   If the file extension is unknown to imagelib, this will first write out a PNG
+   and then convert that to the desired format using the "convert"
+   command from imagemagick.
+*)
+val writefile : string -> Image.image -> unit
+
+val size : string -> int * int
+
+val openfile : string -> Image.image

--- a/unix/imageUtil_unix.ml
+++ b/unix/imageUtil_unix.ml
@@ -1,0 +1,91 @@
+open ImageUtil
+
+(** [chop_extension' fname] is the same as [Filename.chop_extension fname] but
+    if [fname] does not have an extension, [fname] is returned instead of
+    raising [Invalid_argument]. *)
+let chop_extension' fname =
+  try Filename.chop_extension fname
+  with _ -> fname
+
+
+(** [get_extension fname] returns the extension of the file [fname]. If the
+    file does not have an extension, [Invalid_argument] is raised. *)
+let get_extension fname =
+  let baselen = String.length (chop_extension' fname) in
+  let extlen  = String.length fname - baselen - 1 in
+  if extlen <= 0
+  then let err = Printf.sprintf "No extension in filename '%s'." fname in
+       raise (Invalid_argument err)
+  else String.sub fname (baselen + 1) extlen
+
+
+(** [get_extension' fname] is the same as [get_extension fname] but if [fname]
+    does not have an extension, the empty string is returned and no exception
+    is raised. *)
+let get_extension' fname =
+  try get_extension fname
+  with _ -> ""
+
+
+(*
+ * Reads all the lines in the channel by calling input_line.
+ * Returns a list of strings.
+ *)
+let lines_from_channel ich =
+  let lines = ref [] in
+
+  let rec intfun () =
+    try
+      let l = input_line ich in
+      lines := l :: !lines;
+      intfun ();
+    with
+     | _ -> ()
+  in
+  intfun ();
+  List.rev !lines
+
+(*
+ * Same as lines_from_channel but from a file.
+ *)
+let lines_from_file fn =
+  let ich = open_in_bin fn in
+  let ls = lines_from_channel ich in
+  close_in ich; ls
+
+let chunk_reader_of_in_channel ich : chunk_reader =
+  function
+  | `Bytes num_bytes ->
+    begin try Ok (really_input_string ich num_bytes)
+    with End_of_file -> Error (`End_of_file (pos_in ich))end
+  | `Close -> close_in ich; Ok ""
+
+let chunk_writer_of_out_channel och : chunk_writer =
+  function
+  | `String x ->
+    ( try Ok (output_string och x) with
+      | _ -> Error `Write_error)
+  | `Close ->
+    close_out och; Ok ()
+
+let chunk_reader_of_path fn =
+  chunk_reader_of_in_channel (open_in_bin fn)
+
+
+(* TODO before merging: This was guarding output to channels to ensure the channel was flushed after an exception occurred. Should reinstate.
+let wrap x g f =
+  (try f x with | e -> g x; raise e);
+  g x
+*)
+
+let chunk_writer_of_path fn =
+  chunk_writer_of_out_channel (open_out_bin fn)
+
+(** Define an output channel for the builtin buffered output on Uix.
+    see {!ImageChannels} for more info*)
+
+module Unix_channel
+  : ImageChannels.OUT_CHANNEL with type out_channel = Pervasives.out_channel
+= struct
+  include Pervasives
+end


### PR DESCRIPTION
This implements Unix-dependent helpers, and introduces a `chunk_writer` for implementation-independent output.

ping @rlepigre @rymdhund

EDIT: Also fixes #18  fixes #17 fixes #21 