### PR TITLE
Decompress.1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - opam update
   - opam switch "$OCAML_VERSION"
   - eval $(opam env)
-  - opam install dune decompress.0.8.1
+  - opam install dune decompress.1.1.0
 
 script:
   - make && make install

--- a/imagelib.opam
+++ b/imagelib.opam
@@ -34,7 +34,8 @@ doc: "https://github.com/rlepigre/imagelib"
 depends: [
   "ocaml"        {         >= "4.03.0" }
   "dune"         { build & >= "1.3.0"  }
-  "decompress"   { >= "0.8.1" }
+  "decompress"   { >= "1.1.0" }
+  "stdlib-shims"
 ]
 
 build: [ [ "dune" "build" "-p" name "-j" jobs ] ]

--- a/src/dune
+++ b/src/dune
@@ -5,4 +5,4 @@
  (modules :standard)
  (flags (:standard -safe-string))
  (wrapped false)
- (libraries bigarray checkseum.ocaml decompress))
+ (libraries stdlib-shims bigarray checkseum.ocaml decompress.zl))

--- a/src/imageGIF.ml
+++ b/src/imageGIF.ml
@@ -16,7 +16,7 @@
  *
  * Copyright (C) 2014 Rodolphe Lepigre.
  *)
-open Pervasives
+open Stdlib
 open ImageUtil
 open Image
 

--- a/src/imageJPG.ml
+++ b/src/imageJPG.ml
@@ -16,7 +16,7 @@
  *
  * Copyright (C) 2014 Rodolphe Lepigre.
  *)
-open Pervasives
+open Stdlib
 open ImageUtil
 open Image
 

--- a/src/imagePPM.ml
+++ b/src/imagePPM.ml
@@ -16,7 +16,7 @@
  *
  * Copyright (C) 2014 Rodolphe Lepigre.
  *)
-open Pervasives
+open Stdlib
 open ImageUtil
 open Image
 

--- a/src/imageUtil.ml
+++ b/src/imageUtil.ml
@@ -39,7 +39,7 @@ let chunk_printf : 'x. chunk_writer ->
   ('x, unit, string, unit) format4 -> 'x = fun och ->
   Printf.kprintf (chunk_write och)
 
-open Pervasives
+open Stdlib
 
 
 (*

--- a/src/imageXCF.ml
+++ b/src/imageXCF.ml
@@ -16,7 +16,7 @@
  *
  * Copyright (C) 2014 Rodolphe Lepigre.
  *)
-open Pervasives
+open Stdlib
 open ImageUtil
 open Image
 

--- a/unix/imageUtil_unix.ml
+++ b/unix/imageUtil_unix.ml
@@ -89,7 +89,7 @@ let chunk_writer_of_path fn =
     see {!ImageChannels} for more info*)
 
 module Unix_channel
-  : ImageChannels.OUT_CHANNEL with type out_channel = Pervasives.out_channel
+  : ImageChannels.OUT_CHANNEL with type out_channel = Stdlib.out_channel
 = struct
-  include Pervasives
+  include Stdlib
 end


### PR DESCRIPTION
On top of #33 I believe. An update to `decompress.1.1.0` and remove deprecated use of `Pervasives` (replaced by `Stdlib`).