### PR TITLE
try to fix alpha handling for GIF and resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,44 @@ make
 make install
 ```
 
+Imagetool
+---------
+
+`app/imagetool.ml` contains an example binary that acts as a command-line interface to many of the functions in the library. It will be installed as `imagetool` or `imagetool.exe` if you use **opam** to install the library, and otherwise it will be in `_build/default/app/imagetool.exe`
+
+```
+usage: /home/user/ocaml/imagelib/_build/default/app/imagetool.exe [args] INPUT-FILE [OUTPUT-FILE]
+Displays a picture in the terminal, or convert it (if OUTPUT-FILE is specified)
+The OUTPUT-FILE is a template; any '#' will be replaced with
+the frame number (useful if the image has multiple frames)
+Options:
+--irc | --vt100   Output to terminal using escape codes
+ \--character     Fill character(s) for text-mode output
+--resize          Set output dimensions. Syntax: '80x25' | '10%'
+  \--gamma        Adjust/reinterpret gamma
+--crop-x WIDTH    Crop final output to WIDTH pixels
+--crop-y HEIGHT   Crop final output to HEIGHT pixels
+--frames RANGE    Only operate on RANGE frames from a multi-frame file format
+                  (like an animated GIF). The format is comma-separated with '-' separating each range
+                    example: --frames 1-10,20-30,50-
+                    example: --frames -200,300-400
+--background      Set background color for transparency using RGB,
+                  e.g. '0xFF0000' is red. Defaults to black.
+```
+
+*Example: Displaying an animated GIF in the terminal with a pink background color:*
+```shell
+imagetool --background 0xff00ff turtle.gif
+```
+
+*Example: Resizing specific frames from a GIF file and exporting them to individual PNG files:*
+```shell
+$ imagetool --resize '50%' --frames -2,3-4,6- turtle.gif small-\#.png
+$ ls
+small-1.png small-2.png small-3.png small-4.png small-6.png small-7.png
+```
+
+
 Fuzzing
 -------
 

--- a/app/imagetool.ml
+++ b/app/imagetool.ml
@@ -191,6 +191,9 @@ let () =
   in
   match config with
   | { display_mode = Some `VT100 ; background ; character ; frames ; _ } ->
+    (* TODO: only the first frame should paint the alpha color; after that
+       we should use the background color when the image is emitting alpha
+       updates *)
     (* print to terminal: using 24-bit color escape codes  *)
     foreach_img ~frames
       (fun () -> Printf.printf "\x1b[0;0H") (* a bit annoying for debugging *)

--- a/app/imagetool.ml
+++ b/app/imagetool.ml
@@ -119,7 +119,7 @@ let () =
   let handle_resize input_img =
     let doit x y =
       let x, y = max 1 x, max 1 y in
-      let dst = Image.create_rgb ~alpha:false x y in
+      let dst = Image.create_rgb ~alpha:true x y in
       Image.Resize.scale_copy_layer dst ~src:input_img config.gamma
     in
     match config.resize with

--- a/app/imagetool.ml
+++ b/app/imagetool.ml
@@ -155,8 +155,11 @@ let () =
       (ImageUtil_unix.chunk_reader_of_path config.input_file) in
   let handle_resize input_img =
     let doit x y =
+      let alpha = match input_img.Image.pixels with
+        | RGBA _ | GreyA _ -> true
+        | RGB _ | Grey _ -> false in
       let x, y = max 1 x, max 1 y in
-      let dst = Image.create_rgb ~alpha:true x y in
+      let dst = Image.create_rgb ~alpha x y in
       Image.Resize.scale_copy_layer dst ~src:input_img config.gamma
     in
     match config.resize with

--- a/app/imagetool.ml
+++ b/app/imagetool.ml
@@ -1,3 +1,25 @@
+module FrameSelect = struct
+  type t = (int * int) list
+  let of_string frm : t =
+    String.split_on_char ',' frm
+    |> List.map (fun selection ->
+        begin match String.split_on_char '-' selection with
+          | [single] -> single,single
+          | [first ; last] -> first, last
+          | exception Not_found -> selection, selection
+              | _ ->
+                invalid_arg (Printf.sprintf
+                               "Unable to parse frame selection: %S" selection)
+        end |> fun (first,last) ->
+        (match first with "" -> 1 | _ -> int_of_string first),
+        (match last with "" -> max_int | _ -> int_of_string last)
+      )
+    |> List.sort compare
+  let matches t frame_number =
+    List.exists (fun (first,last) ->
+        frame_number >= first && frame_number <= last) t
+end
+
 type config = {
   input_file : string;
   display_mode: [`IRC | `VT100] option;
@@ -8,6 +30,7 @@ type config = {
   gamma: float ;
   resize : [`Original | `Percent of float | `Dim of (int * int) ];
   output_file : string option;
+  frames: FrameSelect.t; (* frames from multi-frame image, eg animated GIF *)
 }
 
 let arg_parser array : config =
@@ -17,6 +40,9 @@ let arg_parser array : config =
     function
     | [] -> config, Array.of_list leftover
     | "--help"::_ -> config, [| ""; "" |] (* return extra args *)
+    | "--frames"::frm::tl ->
+      let frames = FrameSelect.of_string frm in
+      erase leftover {config with frames} tl
     | "--background"::bg::tl ->
       erase leftover {config with background = int_of_string bg} tl
     | "--character"::fill::tl ->
@@ -63,6 +89,7 @@ let arg_parser array : config =
       gamma = 2.2;
       resize = `Original ;
       output_file = None ;
+      frames = [1, max_int];
       crop_x = 65535;
       crop_y = 65535;
     } (Array.to_list array |> List.tl)
@@ -77,6 +104,8 @@ let arg_parser array : config =
       Sys.executable_name;
     Printf.eprintf "Displays a picture in the terminal, or convert it ";
     Printf.eprintf "(if OUTPUT-FILE is specified)\n" ;
+    Printf.eprintf "The OUTPUT-FILE is a template; any '#' will be replaced with \n";
+    Printf.eprintf "the frame number (useful if the image has multiple frames)\n";
     Printf.eprintf "Options:\n";
     Printf.eprintf "--irc | --vt100   Output to terminal using escape codes\n" ;
     Printf.eprintf " \\--character     Fill character(s) for text-mode output\n";
@@ -84,9 +113,17 @@ let arg_parser array : config =
       "--resize          Set output dimensions. Syntax: '80x25' | '10%%'\n";
     Printf.eprintf "  \\--gamma        Adjust/reinterpret gamma\n";
     Printf.eprintf
-      "--crop-x WIDTH         Crop final output to WIDTH pixels\n" ;
+      "--crop-x WIDTH    Crop final output to WIDTH pixels\n" ;
     Printf.eprintf
-      "--crop-y HEIGHT        Crop final output to HEIGHT pixels\n" ;
+      "--crop-y HEIGHT   Crop final output to HEIGHT pixels\n" ;
+    Printf.eprintf
+      "--frames RANGE    Only operate on RANGE frames from a multi-frame file format\n" ;
+    Printf.eprintf
+      "                  (like an animated GIF). The format is comma-separated with '-' separating each range\n" ;
+    Printf.eprintf
+      "          y          example: --frames 1-10,20-30,50-\n" ;
+    Printf.eprintf
+      "                    example: --frames -200,300-400\n" ;
     Printf.eprintf "--background      Set background color for transparency";
     Printf.eprintf " using RGB,\n";
     Printf.eprintf "                  e.g. '0xFF0000' is red.";
@@ -132,53 +169,60 @@ let () =
     {img with width = min img.width config.crop_x ;
               height = min img.height config.crop_y }
   in
-  let foreach_img f_pre f =
-    let rec loop last_parsed_ts state =
+  let foreach_img ~frames f_pre f =
+    let rec loop frame_number last_parsed_ts state =
       match read_next state with
       | None, _, _ -> ()
       | Some o'img, delay, state ->
         let img = handle_resize o'img |> handle_crop in
         let delay = float delay /. 100. in
         let parsed_ts = Unix.gettimeofday() in
-        Unix.sleepf (max 0. (delay -. (parsed_ts -. last_parsed_ts)));
-        f_pre ();
-        foreach_pixel f img ;
-        Printf.printf "%!";
-        if state <> None then loop parsed_ts state
-    in loop 0. None
+        if FrameSelect.matches frames frame_number then begin
+          Unix.sleepf (max 0. (delay -. (parsed_ts -. last_parsed_ts)));
+          f_pre ();
+          foreach_pixel f img ;
+          Printf.printf "%!";
+        end ;
+        if state <> None then loop (succ frame_number) parsed_ts state
+    in loop 1 0. None
   in
   match config with
-  | { display_mode = Some `VT100 ; background ; character ; _ } ->
+  | { display_mode = Some `VT100 ; background ; character ; frames ; _ } ->
     (* print to terminal: using 24-bit color escape codes  *)
-    foreach_img
+    foreach_img ~frames
       (fun () -> Printf.printf "\x1b[0;0H") (* a bit annoying for debugging *)
       (ImageUtil.colorize_rgba8888 ?character ~background) ;
     print_string "\x1b[0m"
 
-  | { display_mode = Some `IRC ; background ; _ } ->
+  | { display_mode = Some `IRC ; background ; frames ; _ } ->
     (* print to terminal, using IRC 24-bit color escape codes *)
-    foreach_img (fun () -> ())
+    foreach_img ~frames (fun () -> ())
       (ImageUtil.colorize_rgba8888_irc ~background)
 
-  | { output_file = Some fn ; _ } ->
-    let img = match read_next None with
-      | Some img, _, None -> img
-      | None, _, _ -> Printf.eprintf "No frames in image." ; exit 1
-      | Some img, _, (Some _ as st) when (None, 0, None) = read_next st -> img
-      | Some _, _, Some _ ->
-        Printf.eprintf "TODO NOT IMPLEMENTED: Writing image with >1 frames" ;
+  | { output_file = Some fn ; frames ; _ } ->
+    let output_this fn img =
+      let img = handle_resize img |> handle_crop in
+      (* output to filename specified in second argument *)
+      if Sys.(file_exists fn)
+      then begin
+        Printf.eprintf "Output file %S already exists\n" fn ;
         exit 1
+      end else begin
+        let extension = extension fn in
+        let wr = ImageUtil_unix.chunk_writer_of_path fn in
+        ImageLib.writefile ~extension wr img
+      end
     in
-    let img = handle_resize img |> handle_crop in
-    (* output to filename specified in second argument *)
-    if Sys.(file_exists fn)
-    then begin
-      Printf.eprintf "Output file already exists\n" ;
-      exit 1
-    end else begin
-      let extension = extension fn in
-      let wr = ImageUtil_unix.chunk_writer_of_path fn in
-      ImageLib.writefile ~extension wr img
-    end
+    let rec loop frame_number = function
+      | Some image, _delay, state ->
+        if FrameSelect.matches frames frame_number then
+          let fn = match String.split_on_char '#' fn with
+            | exception _ -> fn
+            | parts -> String.concat (string_of_int frame_number) parts in
+          output_this fn image ;
+        loop (succ frame_number) (read_next state)
+      | None , _, _ -> exit 0
+    in
+    loop 1 (read_next None)
 
   | _ -> invalid_arg "too many argv arguments"

--- a/src/image.ml
+++ b/src/image.ml
@@ -503,25 +503,23 @@ end = struct
 
     let alphasum = cubic_spline_fit yfrac p0 p1 p2 p3 in
     (* alphasum goes from 0.0 to 1.0, it may be NaN *)
-    let pixel = Array.make 4 0.0 in
-    for b = 0 to 3 do
-      let p0 = cubic_spline_fit
-          xfrac (s0.(0 + b)  *. s0.( 3)) (s0.( 4 + b)  *. s0.( 7))
-          (s0.(8 + b)  *. s0.(11))     (s0.(12 + b) *. s0.(15)) in
-      let p1 = cubic_spline_fit xfrac
-          (s1.(0 + b) *. s1.( 3)) (s1.( 4 + b) *. s1.(7))
-          (s1.(8 + b) *. s1.(11)) (s1.(12 + b) *. s1.(15)) in
-      let p2 = cubic_spline_fit
-          xfrac
-          (s2.(0 + b) *. s2.( 3)) (s2.( 4 + b) *. s2.(7))
-          (s2.(8 + b) *. s2.(11)) (s2.(12 + b) *. s2.(15)) in
-      let p3 = cubic_spline_fit xfrac
-          (s3.(0 + b) *. s3.( 3)) (s3.( 4 + b) *. s3.(7))
-          (s3.(8 + b) *. s3.(11)) (s3.(12 + b) *. s3.(15)) in
-      let sum = cubic_spline_fit yfrac p0 p1 p2 p3 /. alphasum in
-      pixel.(b) <- clamp sum 0. 255. ;
-    done ;
-    pixel
+    Array.init 4 (fun b -> (* expression forms a rgba8888 array *)
+        let p0 = cubic_spline_fit
+            xfrac (s0.(0 + b)  *. s0.( 3)) (s0.( 4 + b)  *. s0.( 7))
+            (s0.(8 + b)  *. s0.(11))     (s0.(12 + b) *. s0.(15)) in
+        let p1 = cubic_spline_fit xfrac
+            (s1.(0 + b) *. s1.( 3)) (s1.( 4 + b) *. s1.(7))
+            (s1.(8 + b) *. s1.(11)) (s1.(12 + b) *. s1.(15)) in
+        let p2 = cubic_spline_fit
+            xfrac
+            (s2.(0 + b) *. s2.( 3)) (s2.( 4 + b) *. s2.(7))
+            (s2.(8 + b) *. s2.(11)) (s2.(12 + b) *. s2.(15)) in
+        let p3 = cubic_spline_fit xfrac
+            (s3.(0 + b) *. s3.( 3)) (s3.( 4 + b) *. s3.(7))
+            (s3.(8 + b) *. s3.(11)) (s3.(12 + b) *. s3.(15)) in
+        let sum = cubic_spline_fit yfrac p0 p1 p2 p3 /. alphasum in
+        clamp sum 0. 255.
+      )
 
 
   let linear2exp linear gamma =

--- a/src/image.ml
+++ b/src/image.ml
@@ -430,7 +430,7 @@ end = struct
   let [@inline] get_rgba o_x o_y gamma (image:image) : float array =
     let x = clamp o_x 0 (image.width -1) in
     let y = clamp o_y 0 (image.height -1) in
-    let colors = try read_rgb image x y (fun r g b -> [| r;g;b |]) with
+    let colors = try read_rgba image x y (fun r g b a -> [| r;g;b;a |]) with
       | Invalid_argument _ ->
         Printf.eprintf "x:%d[%d] y:%d[%d]" x y image.width image.height ;
         failwith ("read_rgb failed: " ^ __LOC__)
@@ -502,9 +502,9 @@ end = struct
     let p3 = cubic_spline_fit xfrac s3.(3) s3.(7) s3.(11) s3.(15) in
 
     let alphasum = cubic_spline_fit yfrac p0 p1 p2 p3 in
-    assert (alphasum > 0.0) ;
+    (* alphasum goes from 0.0 to 1.0, it may be NaN *)
     let pixel = Array.make 4 0.0 in
-    for b = 0 to 2 do
+    for b = 0 to 3 do
       let p0 = cubic_spline_fit
           xfrac (s0.(0 + b)  *. s0.( 3)) (s0.( 4 + b)  *. s0.( 7))
           (s0.(8 + b)  *. s0.(11))     (s0.(12 + b) *. s0.(15)) in
@@ -521,7 +521,6 @@ end = struct
       let sum = cubic_spline_fit yfrac p0 p1 p2 p3 /. alphasum in
       pixel.(b) <- clamp sum 0. 255. ;
     done ;
-    pixel.(3) <- clamp alphasum 0. 255. ;
     pixel
 
 

--- a/src/imageGIF.ml
+++ b/src/imageGIF.ml
@@ -546,7 +546,7 @@ https://www.commandlinefanatic.com/cgi-bin/showarticle.cgi?article=art011*)
 
               (* initialize with bgcolor if there's a global color table: *)
               fill_background_color buffer gct header.bg_color_index ;
-              fill_alpha buffer 0xff;
+              (*fill_alpha buffer 0xff;*)
 
               Some gct
           in
@@ -606,12 +606,13 @@ https://www.commandlinefanatic.com/cgi-bin/showarticle.cgi?article=art011*)
             (* http://webreference.com/content/studio/disposal.html *)
             let graphics_disposal_method = match (packed lsr 2) land 0b111 with
               | 0 ->
-                Printf.printf "graphic disposal method not specified\n%!"
+                ()
+                (*Printf.eprintf "graphic disposal method not specified\n%!"*)
               (* Use this option to replace one full-size, non-transparent frame with another. *)
               (* TODO *)
 
               | 1 -> (* do not dispose of graphic*)
-                (*Printf.printf "DO NOT DISPOSE\n%!";*)
+                (*Printf.eprintf "DO NOT DISPOSE\n%!";*)
                 fill_alpha gif_state.buffer 0xff;
               (*  In this option, any pixels not covered up by the next frame continue to display. This is the setting used most often for optimized animations. In the flashing light animation, we wanted to keep the first frame displaying, so the subsequent optimized frames would just replace the part that we wanted to change. That's what Do Not Dispose does. *)
                 ()
@@ -731,7 +732,8 @@ The thing to remember about Restore to Previous is that it's not necessarily the
               (fun r g b -> function
                  (* optimization: if the dot is invisible, only copy over the alpha value: y*)
                  | 0x00 -> begin match gif_state.buffer.pixels with
-                     | RGBA (_,_,_,aa) -> Pixmap.set aa (left+x) (top+y) 0x00
+                     | RGBA (_,_,_,aa) ->
+                       Pixmap.set aa (left+x) (top+y) 0x00
                      | _ -> failwith "gif_state.buffer.pixels is not rgba"
                    end
                  | a ->

--- a/src/imageGIF.ml
+++ b/src/imageGIF.ml
@@ -626,7 +626,6 @@ https://www.commandlinefanatic.com/cgi-bin/showarticle.cgi?article=art011*)
                  | Some gct ->
                    fill_background_color gif_state.buffer
                      gct gif_state.header.bg_color_index) ;
-                (*Image.fill_alpha gif_state.buffer 0xFF*)
 
               | 4 -> (* overwrite graphic with previous graphic*)
                 Image.fill_alpha gif_state.buffer 0xFF
@@ -730,12 +729,13 @@ The thing to remember about Restore to Previous is that it's not necessarily the
             if y+top < 0 || y+top >= buffer.height then () else
             Image.read_rgba image x y
               (fun r g b -> function
+                 (* optimization: if the dot is invisible, only copy over the alpha value: y*)
                  | 0x00 -> begin match gif_state.buffer.pixels with
-                     | RGBA (_,_,_,aa) -> Pixmap.set aa (left+x) (top+y) 0xff
+                     | RGBA (_,_,_,aa) -> Pixmap.set aa (left+x) (top+y) 0x00
                      | _ -> failwith "gif_state.buffer.pixels is not rgba"
                    end
-                 | _ ->
-                   Image.write_rgb gif_state.buffer (left+x) (top+y) r g b)
+                 | a ->
+                   Image.write_rgba gif_state.buffer (left+x) (top+y) r g b a)
           done
         done ;
         Some gif_state.buffer, gif_state.display_time, Some gif_state


### PR DESCRIPTION
This PR aims to fix https://github.com/rlepigre/ocaml-imagelib/issues/42 by adding alpha channel handling for the cubic interpolation resizing, and making the GIF reader default to transparent images.

It is possible this in turn will break GIFs that define a background color (but do not use transparency).
I did not have such a GIF lying around, so I was unable to test that.