### PR TITLE
OCaml 5.0 compatibility

### DIFF
--- a/unix/dune
+++ b/unix/dune
@@ -3,4 +3,4 @@
  (public_name imagelib.unix)
  (synopsis "Image library with unix bindings")
  (wrapped false)
- (libraries imagelib))
+ (libraries imagelib unix))


### PR DESCRIPTION
From the latest failed build on [check.ocamllabs.io](http://check.ocamllabs.io/log/1662116091-418227c38ed4e28a0827786e5e9e50b9547c0b27/5.0/bad/imagelib.20210511):

```
OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
automatically added to the search path, but you should add -I +unix to the
command-line to silence this alert (e.g. by adding unix to the list of
libraries in your dune file, or adding use_unix to your _tags file for
ocamlbuild, or using -package unix for ocamlfind).
```

It's not quite clear why this currently breaks the build, but this should fix it anyway.